### PR TITLE
Allow creating multiple hemigrams for a specific date

### DIFF
--- a/app/controllers/graphs_controller.rb
+++ b/app/controllers/graphs_controller.rb
@@ -18,8 +18,8 @@ class GraphsController < ApplicationController
       {
         name: parameter,
         data: group
-          .sort_by(&:date)
-          .map { |entry| [entry.date.to_date, entry.chart_value.to_f] }
+          .sort_by(&:record_date)
+          .map { |entry| [entry.record_date.date.to_date, entry.chart_value.to_f] }
       }
     end.compact.flatten
   end

--- a/app/controllers/hemigram_dates_controller.rb
+++ b/app/controllers/hemigram_dates_controller.rb
@@ -3,22 +3,33 @@
 class HemigramDatesController < ApplicationController
   def new
     @hemigram_date = Hemigrams::Date.new
+    @hemigram_date.hemigrams.build(user_id: current_user.id)
   end
 
   def create
-    @hemigram_date = Hemigrams::Date.new(hemigram_date_params.merge(user: current_user))
+    return 'Unauthorized. Wrong user' unless current_user.id.to_s == params[:view_user_id]
 
-    return 'Unauthorized. Wrong user' unless current_user.id == params[:view_user_id]
+    # find or initialize a hemigram date object
+    @hemigram_date = Hemigrams::Date.find_or_initialize_by(date: hemigram_date_params[:date], user: current_user)
 
-    @hemigram = @hemigram_date.hemigrams.build(user: current_user)
+    respond_to do |format|
+      if @hemigram_date.persisted? || @hemigram_date.save
+        # create the associated hemigrams for the date from the params
+        hemigrams_params[:hemigrams_attributes].each do |param|
+          # remove the destroy key and add the current user to the attributes to build the hemigram
+          @hemigram_date.hemigrams.build(param[1].to_h.except!('_destroy').merge(user: current_user))
+        end
+      else
+        format.html { render :new, status: :unprocessable_entity } # need the status to show errors with turbo
+      end
 
-    if @hemigram_date.save
-      respond_to do |format|
+      # Save the build hemigram date with associated hemigrams
+      if @hemigram_date.save
         format.html { redirect_to view_user_hemigrams_path, notice: ErrorHandling::SUCCESSFUL_CREATE }
         format.turbo_stream { flash.now[:notice] = ErrorHandling::SUCCESSFUL_CREATE }
+      else
+        format.html { render :new, status: :unprocessable_entity } # need the status to show errors with turbo
       end
-    else
-      render :new, status: :unprocessable_entity # need the status to show errors with turbo
     end
   end
 
@@ -26,6 +37,10 @@ class HemigramDatesController < ApplicationController
 
   def hemigram_date_params
     params.require(:hemigrams_date).permit(:date)
+  end
+
+  def hemigrams_params
+    params.require(:hemigrams_date).permit(:date, hemigrams_attributes: %i[id parameter value unit _destroy user])
   end
 end
 

--- a/app/controllers/hemigram_dates_controller.rb
+++ b/app/controllers/hemigram_dates_controller.rb
@@ -4,6 +4,37 @@ class HemigramDatesController < ApplicationController
   end
 
   def create
-    @hemigram = @hemigram_date.build_hemigram(user: current_user)
+    @hemigram_date = Hemigrams::Date.new(hemigram_date_params)
+
+    return 'Wrong user' unless current_user == params[:view_user_id]
+
+    @hemigram = @hemigram_date.hemigrams.build(user: current_user)
+
+    if @hemigram_date.save
+      respond_to do |format|
+        format.html { redirect_to view_user_hemigrams_path, notice: ErrorHandling::SUCCESSFUL_CREATE }
+        format.turbo_stream { flash.now[:notice] = ErrorHandling::SUCCESSFUL_CREATE }
+      end
+    else
+      render :new, status: :unprocessable_entity # need the status to show errors with turbo
+    end
+  end
+
+  private
+
+  def hemigram_date_params
+    params.require(:hemigrams_date).permit(:date)
   end
 end
+
+# TODOs:
+# check the create action
+# update the hemigram form and remove the date
+# when creating a hemigram, it should use the hemigram date relationship (find the id of the hemigram date object)
+
+# in the entry_fields partial, I need to render the turbo frame for create new hemigram partial. I also need to allow
+# generating multiple hemigrams, as fields_for :hemigram and automatically adding such fields when clicking add new hemigram
+# when I then save the hemigram date form, it should automatically create the hemigrams for the user and
+# render them above the hemigram list
+
+# later: I want to group the hemigrams by hemigram_date on the users hemigrams index page

--- a/app/controllers/hemigram_dates_controller.rb
+++ b/app/controllers/hemigram_dates_controller.rb
@@ -1,0 +1,9 @@
+class HemigramDatesController < ApplicationController
+  def new
+    @hemigram_date = Hemigrams::Date.new
+  end
+
+  def create
+    @hemigram = @hemigram_date.build_hemigram(user: current_user)
+  end
+end

--- a/app/controllers/hemigram_dates_controller.rb
+++ b/app/controllers/hemigram_dates_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HemigramDatesController < ApplicationController
   def new
     @hemigram_date = Hemigrams::Date.new

--- a/app/controllers/hemigram_dates_controller.rb
+++ b/app/controllers/hemigram_dates_controller.rb
@@ -6,9 +6,9 @@ class HemigramDatesController < ApplicationController
   end
 
   def create
-    @hemigram_date = Hemigrams::Date.new(hemigram_date_params)
+    @hemigram_date = Hemigrams::Date.new(hemigram_date_params.merge(user: current_user))
 
-    return 'Wrong user' unless current_user == params[:view_user_id]
+    return 'Unauthorized. Wrong user' unless current_user.id == params[:view_user_id]
 
     @hemigram = @hemigram_date.hemigrams.build(user: current_user)
 

--- a/app/controllers/hemigrams_controller.rb
+++ b/app/controllers/hemigrams_controller.rb
@@ -64,7 +64,7 @@ class HemigramsController < ApplicationController
     shorts = Admin::Hemigrams::ParameterMetadata.short(parameter)
 
     respond_to do |format|
-      format.html { render("hemigrams/frames/unit_form_select", locals: { options:, shorts:, hemigram_id:}) }
+      format.html { render('hemigrams/frames/unit_form_select', locals: { options:, shorts:, hemigram_id: }) }
     end
   end
 

--- a/app/controllers/hemigrams_controller.rb
+++ b/app/controllers/hemigrams_controller.rb
@@ -23,6 +23,9 @@ class HemigramsController < ApplicationController
     @hemigram = current_user.hemigrams.build(hemigram_params)
     @hemigram.short = Admin::Hemigrams::ParameterMetadata.short(@hemigram.parameter)
     @hemigram.hemigrams_parameter_associations.build(parameter_metadata:)
+    existing_date_record = current_user.record_dates.find_or_initialize_by(date: @hemigram_date)
+
+    @hemigram.record_date.date = @hemigram.date
 
     if @hemigram.save
       respond_to do |format|

--- a/app/controllers/hemigrams_controller.rb
+++ b/app/controllers/hemigrams_controller.rb
@@ -23,9 +23,9 @@ class HemigramsController < ApplicationController
     @hemigram = current_user.hemigrams.build(hemigram_params)
     @hemigram.short = Admin::Hemigrams::ParameterMetadata.short(@hemigram.parameter)
     @hemigram.hemigrams_parameter_associations.build(parameter_metadata:)
-    existing_date_record = current_user.record_dates.find_or_initialize_by(date: @hemigram_date)
-
-    @hemigram.record_date.date = @hemigram.date
+    binding.pry
+    existing_record_object = current_user.record_dates.find_or_initialize_by(date: @hemigram.date)
+    @hemigram.record_date = existing_record_object
 
     if @hemigram.save
       respond_to do |format|

--- a/app/controllers/hemigrams_controller.rb
+++ b/app/controllers/hemigrams_controller.rb
@@ -23,7 +23,6 @@ class HemigramsController < ApplicationController
     @hemigram = current_user.hemigrams.build(hemigram_params)
     @hemigram.short = Admin::Hemigrams::ParameterMetadata.short(@hemigram.parameter)
     @hemigram.hemigrams_parameter_associations.build(parameter_metadata:)
-    binding.pry
     existing_record_object = current_user.record_dates.find_or_initialize_by(date: @hemigram.date)
     @hemigram.record_date = existing_record_object
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,6 +27,7 @@ class UsersController < ApplicationController
     # TODO: add filter field
     # TODO: add pagination (copy from hemigram index action)
     @hemigrams = @user.hemigrams.order(date: :desc)
+    @hemigram_dates = @hemigrams.map(&:record_date).sort_by(&:date).reverse
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,7 +27,7 @@ class UsersController < ApplicationController
     # TODO: add filter field
     # TODO: add pagination (copy from hemigram index action)
     @hemigrams = @user.hemigrams.order(date: :desc)
-    @hemigram_dates = @hemigrams.map(&:record_date).sort_by(&:date).reverse
+    @hemigram_dates = @user.record_dates.order(date: :desc)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,10 @@ class UsersController < ApplicationController
     @user_parameter_ids = Hemigram.for_user(current_user).map(&:parameter_metadata).flat_map(&:ids).uniq
   end
 
-  def edit; end
+  def edit
+    # ensures that we always have at least the default security questions
+    generate_default_security_questions if @user.security_questions.empty?
+  end
 
   def update
     @user.is_being_updated = true # needed to only run validations on update
@@ -51,5 +54,9 @@ class UsersController < ApplicationController
     user_params[:security_questions].to_h.map do |_idx, question|
       [question[:question], question[:answer]]
     end
+  end
+
+  def generate_default_security_questions
+    @user.update(security_questions: @user.select_random_questions_with_answers)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,8 @@ class UsersController < ApplicationController
   end
 
   def hemigrams
+    # TODO: add filter field
+    # TODO: add pagination (copy from hemigram index action)
     @hemigrams = @user.hemigrams.order(date: :desc)
   end
 

--- a/app/helpers/hemigrams_helper.rb
+++ b/app/helpers/hemigrams_helper.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 module HemigramsHelper
-  def form_url
-    @hemigram.persisted? ? hemigram_path(@hemigram) : hemigrams_path(parameter: nil)
+  def form_url(object, path)
+    object.persisted? ? public_send("#{path}_path", object) : public_send("#{path}s_path" , parameter: nil)
   end
 
-  def form_method
-    @hemigram.persisted? ? :patch : :post
+  def form_method(object)
+    object.persisted? ? :patch : :post
   end
 
   def options_for_chart_units

--- a/app/helpers/hemigrams_helper.rb
+++ b/app/helpers/hemigrams_helper.rb
@@ -2,7 +2,7 @@
 
 module HemigramsHelper
   def form_url(object, path)
-    object.persisted? ? public_send("#{path}_path", object) : public_send("#{path}s_path" , parameter: nil)
+    object.persisted? ? public_send("#{path}_path", object) : public_send("#{path}s_path", parameter: nil)
   end
 
   def form_method(object)

--- a/app/models/hemigram.rb
+++ b/app/models/hemigram.rb
@@ -38,8 +38,7 @@ class Hemigram < ApplicationRecord
   has_and_belongs_to_many :parameter_metadata, join_table: 'hemigrams_parameter_associations',
                                                class_name: 'Admin::Hemigrams::ParameterMetadata'
 
-  validates :record_date, presence: true, uniqueness: { scope: %i[record_date_id user_id parameter] }
-  validates :date, presence: true # deprecated
+  # validates :record_date, presence: true, uniqueness: { scope: %i[record_date_id user_id parameter] }
   validates :parameter, presence: true
   validates :unit, presence: true
   validates :value, presence: true, numericality: { allow_float: true, greater_than: 0 }
@@ -71,24 +70,24 @@ class Hemigram < ApplicationRecord
   private
 
   def validate_only_one_entry_per_parameter_per_day
-    return unless entry_already_exists_on_date?
+    return unless entry_for_parameter_already_exists_on_date?
 
     return if persisted?
 
-    errors.add(:value, "on #{date.to_date} for #{parameter} already exists")
+    errors.add(:value, "on #{record_date.date.to_date} for #{parameter} already exists")
   end
 
-  def entry_already_exists_on_date?
-    Hemigram.exists?(user_id:, parameter:, date: date.to_date)
+  def entry_for_parameter_already_exists_on_date?
+    Hemigram.exists?(user_id:, parameter:, record_date: record_date.date.to_date)
   end
 
   def validate_date_not_in_future
-    return unless date > Date.current
+    return unless record_date.date > Date.current
 
-    errors.add(:date, "can't be in the future")
+    errors.add(:record_date, "can't be in the future")
   end
 
   def date_present?
-    date.present?
+    record_date.present?
   end
 end

--- a/app/models/hemigram.rb
+++ b/app/models/hemigram.rb
@@ -38,7 +38,7 @@ class Hemigram < ApplicationRecord
   has_and_belongs_to_many :parameter_metadata, join_table: 'hemigrams_parameter_associations',
                                                class_name: 'Admin::Hemigrams::ParameterMetadata'
 
-  validates :record_date, presence: true, uniqueness: { scope: :record_date_id }
+  validates :record_date, presence: true, uniqueness: { scope: %i[record_date_id user_id parameter] }
   validates :date, presence: true # deprecated
   validates :parameter, presence: true
   validates :unit, presence: true

--- a/app/models/hemigram.rb
+++ b/app/models/hemigram.rb
@@ -33,12 +33,13 @@ class Hemigram < ApplicationRecord
   encrypts :chart_value, deterministic: true # deterministic: allows querying the db data
 
   belongs_to :user
-  has_one :record_date, dependent: :destroy, class_name: 'Hemigrams::Date'
+  belongs_to :record_date, foreign_key: :record_date_id, class_name: 'Hemigrams::Date', dependent: :destroy
   has_many :hemigrams_parameter_associations, class_name: 'Hemigrams::ParameterAssociation'
   has_and_belongs_to_many :parameter_metadata, join_table: 'hemigrams_parameter_associations',
-                                               class_name: 'Admin::Hemigrams::ParameterMetadata'
+  class_name: 'Admin::Hemigrams::ParameterMetadata'
 
-  validates :date, presence: true
+  validates :record_date, presence: true, uniqueness: { scope: :hemigram_date_id }
+  validates :date, presence: true # deprecated
   validates :parameter, presence: true
   validates :unit, presence: true
   validates :value, presence: true, numericality: { allow_float: true, greater_than: 0 }

--- a/app/models/hemigram.rb
+++ b/app/models/hemigram.rb
@@ -26,7 +26,7 @@ class Hemigram < ApplicationRecord
   # TODO: the dates attribute can be dropped after the backfilling of the dates
   # this needs to be ensured on production
   # deprecated, I use the record_date association
-  # self.ignored_columns = %i[date]
+  self.ignored_columns = %i[date]
 
   encrypts :parameter, deterministic: true # deterministic: allows querying the db data
   encrypts :value, deterministic: true # deterministic: allows querying the db data

--- a/app/models/hemigram.rb
+++ b/app/models/hemigram.rb
@@ -33,12 +33,12 @@ class Hemigram < ApplicationRecord
   encrypts :chart_value, deterministic: true # deterministic: allows querying the db data
 
   belongs_to :user
-  belongs_to :record_date, foreign_key: :record_date_id, class_name: 'Hemigrams::Date', dependent: :destroy
+  belongs_to :record_date, class_name: 'Hemigrams::Date', dependent: :destroy
   has_many :hemigrams_parameter_associations, class_name: 'Hemigrams::ParameterAssociation'
   has_and_belongs_to_many :parameter_metadata, join_table: 'hemigrams_parameter_associations',
-  class_name: 'Admin::Hemigrams::ParameterMetadata'
+                                               class_name: 'Admin::Hemigrams::ParameterMetadata'
 
-  validates :record_date, presence: true, uniqueness: { scope: :hemigram_date_id }
+  validates :record_date, presence: true, uniqueness: { scope: :record_date_id }
   validates :date, presence: true # deprecated
   validates :parameter, presence: true
   validates :unit, presence: true

--- a/app/models/hemigrams/date.rb
+++ b/app/models/hemigrams/date.rb
@@ -5,6 +5,7 @@ module Hemigrams
   class Date < ApplicationRecord
     self.table_name = 'hemigram_dates'
 
+    belongs_to :user
     has_many :hemigrams, foreign_key: :record_date_id, dependent: :destroy
 
     scope :ordered, -> { order(date: :desc) }

--- a/app/models/hemigrams/date.rb
+++ b/app/models/hemigrams/date.rb
@@ -5,9 +5,7 @@ module Hemigrams
   class Date < ApplicationRecord
     self.table_name = 'hemigram_dates'
 
-    belongs_to :hemigram
-
-    validates :date, presence: true, uniqueness: { scope: :hemigram_id }
+    has_many :hemigrams, foreign_key: :record_date_id, dependent: :destroy
 
     scope :ordered, -> { order(date: :desc) }
   end

--- a/app/models/hemigrams/date.rb
+++ b/app/models/hemigrams/date.rb
@@ -7,6 +7,7 @@ module Hemigrams
 
     belongs_to :user
     has_many :hemigrams, foreign_key: :record_date_id, dependent: :destroy
+    accepts_nested_attributes_for :hemigrams, allow_destroy: true
 
     scope :ordered, -> { order(date: :desc) }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ApplicationRecord
   ].freeze
 
   has_many :hemigrams, dependent: :destroy
+  has_many :record_dates, class_name: 'Hemigrams::Date', dependent: :destroy
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable, :validatable, :recoverable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,12 @@ class User < ApplicationRecord
     save
   end
 
+  def select_random_questions_with_answers
+    SECURITY_QUESTIONS.sample(3).map do |question|
+      [question, 'Your answer']
+    end
+  end
+
   private
 
   def being_updated?
@@ -107,11 +113,5 @@ class User < ApplicationRecord
   def generate_default_security_questions_and_answers
     self.security_questions = select_random_questions_with_answers
     save
-  end
-
-  def select_random_questions_with_answers
-    SECURITY_QUESTIONS.sample(3).map do |question|
-      [question, 'Your answer']
-    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,6 +74,10 @@ class User < ApplicationRecord
     end
   end
 
+  def custom_security_questions?
+    validates_security_questions_present_and_unique
+  end
+
   private
 
   def being_updated?

--- a/app/views/hemigram_dates/_empty_state.html.haml
+++ b/app/views/hemigram_dates/_empty_state.html.haml
@@ -1,0 +1,4 @@
+.d-flex.justify-content-center.mt-5
+  .w-50.rounded.bg-white.p-3.d-flex.flex-column.shadow.border-dashed.border-dashed
+    %p You have no data yet, start tracking your blood values now
+    .w-30.text-center= link_to 'Add new hemigram', new_view_user_hemigram_date_path(current_user), class: 'btn btn-outline-dark', data: { turbo_frame: 'new_hemigram_date' }

--- a/app/views/hemigram_dates/_entry_fields.html.haml
+++ b/app/views/hemigram_dates/_entry_fields.html.haml
@@ -1,3 +1,3 @@
 .row
   .col.g-3.mb-3
-    = form.date_field :record_date, class: 'datepicker form-control', id: 'input_date', max: Date.current.to_s, min: (Date.current - 100.years).to_s, required: true, placeholder: 'Choose date'
+    = form.date_field :date, class: 'datepicker form-control', id: 'input_date', max: Date.current.to_s, min: (Date.current - 100.years).to_s, required: true, placeholder: 'Choose date'

--- a/app/views/hemigram_dates/_entry_fields.html.haml
+++ b/app/views/hemigram_dates/_entry_fields.html.haml
@@ -1,0 +1,3 @@
+.row
+  .col.g-3.mb-3
+    = form.date_field :date, class: 'datepicker form-control', id: 'input_date', max: Date.current.to_s, min: (Date.current - 100.years).to_s, required: true, placeholder: 'Choose date'

--- a/app/views/hemigram_dates/_entry_fields.html.haml
+++ b/app/views/hemigram_dates/_entry_fields.html.haml
@@ -1,3 +1,3 @@
 .row
   .col.g-3.mb-3
-    = form.date_field :date, class: 'datepicker form-control', id: 'input_date', max: Date.current.to_s, min: (Date.current - 100.years).to_s, required: true, placeholder: 'Choose date'
+    = form.date_field :record_date, class: 'datepicker form-control', id: 'input_date', max: Date.current.to_s, min: (Date.current - 100.years).to_s, required: true, placeholder: 'Choose date'

--- a/app/views/hemigram_dates/_form.html.haml
+++ b/app/views/hemigram_dates/_form.html.haml
@@ -4,6 +4,12 @@
       = form_for @hemigram_date, url: form_url(@hemigram_date, 'view_user_hemigram_date'), method: form_method(@hemigram_date)  do |form|
         = render partial: 'shared/model_errors', locals: { model: @hemigram_date }
         = render partial: 'entry_fields', locals: { form: }
+        = form.fields_for :hemigrams do |hemigram_form|
+          - @hemigram_date.hemigrams.each do |hemigram|
+            = render partial: 'hemigram_fields', locals: { hemigram: , form: hemigram_form}
+          -# = hemigram_form.text_field :value, class: 'form-control', id: 'input_value'
+          = hemigram_form.check_box :_destroy, title: "Check to delete hemigram"
+          = hemigram_form.submit "Add hemigram", name: :add_hemigram
         .row
           .col
             = form.submit(@hemigram_date.new_record? ? 'Save' : 'Update', class: 'btn btn-outline-dark')

--- a/app/views/hemigram_dates/_form.html.haml
+++ b/app/views/hemigram_dates/_form.html.haml
@@ -1,0 +1,11 @@
+.row.rounded.shadow.bg-white.m-3
+  .col
+    .mb-3
+      = form_for @hemigram_date, url: form_url(@hemigram_date, 'view_user_hemigram_date'), method: form_method(@hemigram_date)  do |form|
+        = render partial: 'shared/model_errors', locals: { model: @hemigram_date }
+        = render partial: 'entry_fields', locals: { form: }
+        .row
+          .col
+            = form.submit(@hemigram_date.new_record? ? 'Save' : 'Update', class: 'btn btn-outline-dark')
+            = link_to 'Cancel', new_view_user_hemigram_date_path(current_user), class: "btn btn-outline-dark"
+

--- a/app/views/hemigram_dates/_hemigram_date.html.haml
+++ b/app/views/hemigram_dates/_hemigram_date.html.haml
@@ -1,0 +1,4 @@
+%p= hemigram_date.date
+- if hemigram_date.hemigrams.any?
+  = hemigram_date.hemigrams.each do |hemigram|
+    = render partial: '../hemigrams/hemigram', locals: { hemigram: }

--- a/app/views/hemigram_dates/_hemigram_fields.html.haml
+++ b/app/views/hemigram_dates/_hemigram_fields.html.haml
@@ -1,0 +1,20 @@
+.row
+  .col-md-5.g-3
+    = form.select :parameter, options_for_select(Admin::Hemigrams::ParameterMetadata.all.sort_by{ _1.parameter_name }.map{ |metadata| ["#{metadata.parameter_name.humanize} (#{metadata.abbreviations.join(', ')})", metadata.parameter_name] }, |
+      selected: hemigram.parameter || params[:parameter]),                                                              |
+      { include_blank: 'Select parameter' },                                                                             |
+      class: 'form-select',                                                                                              |
+      id: "parameter-select-#{hemigram.persisted? ? hemigram.id : 'new'}",                                                                                            |
+      required: true, |
+      data: { controller: 'dynamic-select', 'turbo-frame': 'unit_options', url: hemigrams_get_unit_selection_dropdown_options_path, object_id: hemigram.persisted? ? hemigram.id : 'new' } |
+.row.mb-3
+  - unless hemigram.new_record?
+    .col.g-3
+      = form.text_field :short, disabled: true, class: 'form-control', id: 'input_abreviation', placeholder: hemigram.short
+      %div#abbreviation-display
+  .col.g-3
+    = form.text_field :value, class: 'form-control', id: 'input_value', value: (hemigram.value.to_i == 0 ? 'Enter value' : hemigram.value)
+  .col.g-3
+    = turbo_frame_tag "unit_options-#{hemigram.persisted? ? hemigram.id : 'new'}" do
+      = form.select(:unit, options_for_select([hemigram.unit], selected: hemigram.unit),{ include_blank: 'Select unit' }, class: 'form-select', required: true, data: { controller: 'dynamic-select' })
+      #unit-selector

--- a/app/views/hemigram_dates/create.turbo_stream.haml
+++ b/app/views/hemigram_dates/create.turbo_stream.haml
@@ -1,0 +1,5 @@
+= turbo_stream.prepend "hemigrams", partial: "hemigram_dates/hemigram_date", locals: { hemigram_date: @hemigram_date }
+-# the turbo frame with the id new_hemigram on hemigrams page will be substituted by empty string
+= turbo_stream.update 'new_hemigram_date', ""
+-# ensure the flash messages are rendered on the page
+= render_turbo_stream_flash_messages

--- a/app/views/hemigram_dates/new.html.haml
+++ b/app/views/hemigram_dates/new.html.haml
@@ -1,0 +1,14 @@
+.container.mt-5.mb-5
+  .header-title.p-0.m-0
+    %h2
+      %span.text-highlight Create new hemigram for date
+  .mt-5
+    = @hemigram_date
+    = turbo_frame_tag('new_hemigram_date') do
+      .card.mt-2
+        .card-body
+          .card-title Choose a date for your hemigram
+          .card-text= render 'hemigram_dates/form'
+  = blood_tracker_button('All Hemigrams', 'btn-outline-dark')
+  = graphs_button('See your data', 'btn-outline-dark')
+

--- a/app/views/hemigrams/_entry_fields.haml
+++ b/app/views/hemigrams/_entry_fields.haml
@@ -18,5 +18,5 @@
     = turbo_frame_tag "unit_options-#{@hemigram.persisted? ? @hemigram.id : 'new'}" do
       = form.select(:unit, options_for_select([@hemigram.unit], selected: @hemigram.unit),{ include_blank: 'Select unit' }, class: 'form-select', required: true, data: { controller: 'dynamic-select' })
       #unit-selector
-  -# .col.g-3
-  -#   = form.date :record_date, class: 'datepicker form-control', id: 'input_date', max: Date.current.to_s, min: (Date.current - 100.years).to_s, required: true, placeholder: 'Choose date'
+  .col.g-3
+    = form.date :record_date, class: 'datepicker form-control', id: 'input_date', max: Date.current.to_s, min: (Date.current - 100.years).to_s, required: true, placeholder: 'Choose date'

--- a/app/views/hemigrams/_entry_fields.haml
+++ b/app/views/hemigrams/_entry_fields.haml
@@ -18,5 +18,5 @@
     = turbo_frame_tag "unit_options-#{@hemigram.persisted? ? @hemigram.id : 'new'}" do
       = form.select(:unit, options_for_select([@hemigram.unit], selected: @hemigram.unit),{ include_blank: 'Select unit' }, class: 'form-select', required: true, data: { controller: 'dynamic-select' })
       #unit-selector
-  .col.g-3
-    = form.date_field :date, class: 'datepicker form-control', id: 'input_date', max: Date.current.to_s, min: (Date.current - 100.years).to_s, required: true, placeholder: 'Choose date'
+  -# .col.g-3
+  -#   = form.date :record_date, class: 'datepicker form-control', id: 'input_date', max: Date.current.to_s, min: (Date.current - 100.years).to_s, required: true, placeholder: 'Choose date'

--- a/app/views/hemigrams/_form.html.haml
+++ b/app/views/hemigrams/_form.html.haml
@@ -5,7 +5,7 @@
 .row.rounded.shadow.bg-white.m-3
   .col
     .mb-3
-      = form_for @hemigram, url: form_url, method: form_method  do |form|
+      = form_for @hemigram, url: form_url(@hemigram, 'hemigram'), method: form_method(@hemigram)  do |form|
         = render partial: 'shared/model_errors', locals: { model: @hemigram }
         = render partial: 'entry_fields', locals: { form: }
         .row

--- a/app/views/hemigrams/_hemigram.html.haml
+++ b/app/views/hemigrams/_hemigram.html.haml
@@ -1,6 +1,6 @@
 = turbo_frame_tag(hemigram) do
   %li.list-group-item.list-group-item-action.d-flex.align-items-center.shadow
-    .col.align-items-center= hemigram.parameter.humanize
+    .col.align-items-center= hemigram.parameter&.humanize
     .col.text-left= hemigram.value
     .col.text-left= render_unit(hemigram.unit)
     .col.text-left= hemigram.record_date.date

--- a/app/views/hemigrams/_hemigram.html.haml
+++ b/app/views/hemigrams/_hemigram.html.haml
@@ -3,7 +3,6 @@
     .col.align-items-center= hemigram.parameter.humanize
     .col.text-left= hemigram.value
     .col.text-left= render_unit(hemigram.unit)
-    .col.text-left= hemigram.date.to_date
     .col.d-flex.justify-content-end
       .me-3= link_to("Edit", edit_hemigram_path(hemigram), class: "btn btn-outline-dark")
       = link_to 'Delete', hemigram_path(hemigram), data: {turbo_method: :delete, turbo_confirm: 'Are you sure you want to delete this?' }, class: 'btn btn-warning'

--- a/app/views/hemigrams/_hemigram.html.haml
+++ b/app/views/hemigrams/_hemigram.html.haml
@@ -3,6 +3,7 @@
     .col.align-items-center= hemigram.parameter.humanize
     .col.text-left= hemigram.value
     .col.text-left= render_unit(hemigram.unit)
+    .col.text-left= hemigram.record_date.date
     .col.d-flex.justify-content-end
       .me-3= link_to("Edit", edit_hemigram_path(hemigram), class: "btn btn-outline-dark")
       = link_to 'Delete', hemigram_path(hemigram), data: {turbo_method: :delete, turbo_confirm: 'Are you sure you want to delete this?' }, class: 'btn btn-warning'

--- a/app/views/hemigrams/_table.html.haml
+++ b/app/views/hemigrams/_table.html.haml
@@ -15,7 +15,7 @@
           %td= hemigram.short
           %td= hemigram.value
           %td= hemigram.unit
-          %td= hemigram.date.to_date
+          %td= hemigram.record_date.date.to_date
           %td
             = link_to 'Edit', edit_hemigram_path(hemigram), class: 'btn btn-outline-dark'
             = link_to 'Delete', hemigram_path(hemigram), data: {turbo_method: :delete, turbo_confirm: 'Are you sure you want to delete this?' }, class: 'btn btn-warning'

--- a/app/views/hemigrams/frames/unit_form_select.html.haml
+++ b/app/views/hemigrams/frames/unit_form_select.html.haml
@@ -1,4 +1,5 @@
 -# this partial is substituting the select on the form when the first dropdown with parameter name is selected
 -# TODO: turbo_frame tag needs to be dynamic
 = turbo_frame_tag "unit_options-#{hemigram_id}" do
-  = select_tag('hemigram[unit]', options_for_select(options), class: 'form-select', required: true)
+  -# [0] should be the index
+  = select_tag("hemigrams_date[hemigrams_attributes][0][unit]", options_for_select(options), class: 'form-select', required: true)

--- a/app/views/shared/_model_errors.html.haml
+++ b/app/views/shared/_model_errors.html.haml
@@ -1,6 +1,8 @@
 .row.justify-content-center
   .col-md-6.col-s-12
     - if model.errors.any?
-      - model.errors.full_messages.each do |msg|
-        .alert.alert-warning
-          %p= msg
+      .alert.alert-warning
+        - model.errors.full_messages.each do |msg|
+          %ur
+            %li= msg
+

--- a/app/views/users/_security_questions_form.html.haml
+++ b/app/views/users/_security_questions_form.html.haml
@@ -1,6 +1,6 @@
 -# form to update the user security questions and answers
 .mb-5
-  = form_for current_user, url: view_user_path(current_user), method: :patch, data: { turbo: false }  do |f|
+  = form_for current_user, url: view_user_path(current_user), method: form_method(current_user), data: { turbo: false }  do |f|
     = render partial: 'shared/model_errors', locals: { model: current_user }
     - current_user.security_questions.each_with_index do |(question, answer), index|
       .mb-3

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -3,5 +3,5 @@
     %h2
       %span.text-highlight Update your security questions
   .mt-5.mb-5
-    = render partial: 'form', locals: { user: current_user }
+    = render partial: 'security_questions_form', locals: { user: current_user }
   = link_to('Back', :back, class: "btn btn-outline-dark")

--- a/app/views/users/hemigrams.html.haml
+++ b/app/views/users/hemigrams.html.haml
@@ -4,7 +4,7 @@
     %h2
       %span.text-highlight Hemigrams
     .mt-3.d-flex.justify-content-end
-      - if @user.hemigrams.any?
+      - if @hemigram_dates.any?
         .mx-3= graphs_button('Visualize your data', 'btn-outline-dark')
       = turbo_frame_tag "hemigram_turbo_frame" do
         = link_to 'New date', new_view_user_hemigram_date_path(current_user), class: 'btn btn-outline-dark', data: { turbo_frame: 'new_hemigram_date' }

--- a/app/views/users/hemigrams.html.haml
+++ b/app/views/users/hemigrams.html.haml
@@ -7,7 +7,12 @@
       - if @user.hemigrams.any?
         .mx-3= graphs_button('Visualize your data', 'btn-outline-dark')
       = turbo_frame_tag "hemigram_turbo_frame" do
+        = link_to 'New date', new_view_user_hemigram_date_path(current_user), class: 'btn btn-outline-dark', data: { turbo_frame: 'new_hemigram_date' }
         = link_to 'New hemigram', new_hemigram_path, class: 'btn btn-outline-dark', data: { turbo_frame: 'new_hemigram' }
+    .mb-3
+      = turbo_frame_tag('new_hemigram_date') do
+        - unless @hemigram_dates
+          = render partial: 'hemigram_dates/empty_state'
     .mb-3
       = turbo_frame_tag('new_hemigram') do
         - unless @hemigrams

--- a/app/views/users/hemigrams.html.haml
+++ b/app/views/users/hemigrams.html.haml
@@ -19,4 +19,13 @@
           = render partial: 'hemigrams/empty_state'
     = turbo_frame_tag('hemigrams') do
       %ul.mt-3.mb-3.list-group
-        = render @hemigrams
+        - @hemigram_dates.each do |record_date|
+          - date = record_date.date
+          .accordion.accordion-flush#accordion-hemigram-index
+            .accordion-item
+              %h2.accordion-header{id: "heading-#{date}"}
+                %button.accordion-button.collapsed{ type: 'button', 'data-bs-toggle': "collapse", 'data-bs-target': "#collapse-#{date}", 'aria-expanded': "true", 'aria-controls': "collapse-#{date}"}
+                  = [date, date.strftime("%A")].join(' - ')
+              .accordion-collapse.collapse{id: "collapse-#{date}", 'aria-labelledby': "heading-#{date}", 'data-bs-parent': "#accordion-hemigram-index"}
+                .accordion-body
+                  = render record_date.hemigrams

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -40,13 +40,15 @@
           restore access. It is recommended to provide complex and secure answers for enhanced account protection.
           The more intricate your answers, the better and more secure your account will be.
         .mt-2
-          = link_to('Update security questions', edit_view_user_path(current_user), class: 'btn btn-outline-dark')
-        %table.table.mt-2
-          %tbody
-            - @user.security_questions.each do |question, answer|
-              %tr
-                %th{scope: 'row'}= question
-                %td= answer
+          - verb = @user.custom_security_questions? ? 'Update' : 'Set'
+          = link_to("#{verb} security questions", edit_view_user_path(current_user), class: 'btn btn-outline-dark')
+          %table.table.mt-2
+            %tbody
+              - if @user.custom_security_questions?
+                - @user.security_questions.each do |question, answer|
+                  %tr
+                    %th{scope: 'row'}= question
+                    %td= answer
 
     %h2.mt-5 Chart settings
     - if @user_parameter_ids.any?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   resources :view_users, controller: 'users', only: %i[show edit update] do
     get 'hemigrams', on: :member
     resources :hemigrams
+    resources :hemigram_dates
   end
 
   resources :hemigrams

--- a/db/migrate/20240203220824_create_hemigram_dates_table.rb
+++ b/db/migrate/20240203220824_create_hemigram_dates_table.rb
@@ -4,7 +4,6 @@ class CreateHemigramDatesTable < ActiveRecord::Migration[7.0]
   def change
     create_table :hemigram_dates do |t|
       t.date :date, null: false
-      t.references :hemigram, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20240203220825_add_foreign_key_date_id_to_hemigrams.rb
+++ b/db/migrate/20240203220825_add_foreign_key_date_id_to_hemigrams.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddForeignKeyDateIdToHemigrams < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :hemigrams, :record_date, foreign_key: { to_table: :hemigram_dates }
+  end
+end

--- a/db/migrate/20240203224454_add_indexes_to_hemigram_dates.rb
+++ b/db/migrate/20240203224454_add_indexes_to_hemigram_dates.rb
@@ -2,9 +2,10 @@
 
 class AddIndexesToHemigramDates < ActiveRecord::Migration[7.0]
   def change
-    # Ensures that each hemigram entry can only have one date
-    add_index :hemigram_dates, %i[date hemigram_id], unique: true
     # Adding index to the date field to allow ordering efficiently
     add_index :hemigram_dates, :date
+    # Add a composite unique index on hemigram_date_id and parameter fields
+    # this ensures that a specific hemigram can only be associated to a specific date
+    add_index :hemigrams, %i[record_date_id parameter], unique: true
   end
 end

--- a/db/migrate/20240206211955_backfill_hemigram_dates.rb
+++ b/db/migrate/20240206211955_backfill_hemigram_dates.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 # Copies the hemigram.date to the new Hemigrams::Date
-# and creates the new
 class BackfillHemigramDates < ActiveRecord::Migration[7.0]
   def change
-    Hemigram.all.each do |hemigram|
-      hemigram.create_record_date(date: hemigram.date)
+    Hemigram.distinct.pluck(:date).each do |date|
+      # Find or create a Hemigrams::Date record for the current date
+      hemigram_date = Hemigrams::Date.find_or_create_by(date:)
+
+      #Update all hemigrams with the id of the Hemigrams::Date object
+      Hemigram.where(date:).update_all(record_date_id: hemigram_date.id)
     end
   end
 end

--- a/db/migrate/20240206211955_backfill_hemigram_dates.rb
+++ b/db/migrate/20240206211955_backfill_hemigram_dates.rb
@@ -7,7 +7,7 @@ class BackfillHemigramDates < ActiveRecord::Migration[7.0]
       # Find or create a Hemigrams::Date record for the current date
       hemigram_date = Hemigrams::Date.find_or_create_by(date:)
 
-      #Update all hemigrams with the id of the Hemigrams::Date object
+      # Update all hemigrams with the id of the Hemigrams::Date object
       Hemigram.where(date:).update_all(record_date_id: hemigram_date.id)
     end
   end

--- a/db/migrate/20240412120954_add_user_id_to_hemigram_dates_table.rb
+++ b/db/migrate/20240412120954_add_user_id_to_hemigram_dates_table.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUserIdToHemigramDatesTable < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :hemigram_dates, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20240412121644_backfill_hemigram_dates__users.rb
+++ b/db/migrate/20240412121644_backfill_hemigram_dates__users.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# I need to backfill the user_ids for the hemigram dates, to connect the hemigrams,
+# Hemigram dates and users
+class BackfillHemigramDatesUsers < ActiveRecord::Migration[7.0]
+  def change
+    Hemigram.all.each do |hemigram|
+      record_date_object = hemigram.record_date
+      record_date_object.update(user: hemigram.user)
+    end
+  end
+end

--- a/db/migrate/20240426121059_update_unique_index_on_hemigrams_date.rb
+++ b/db/migrate/20240426121059_update_unique_index_on_hemigrams_date.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UpdateUniqueIndexOnHemigramsDate < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :hemigrams, name: :index_hemigrams_on_record_date_id_and_parameter
+    add_index :hemigrams, %i[record_date_id parameter user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_12_121644) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_26_121059) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,7 +44,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_12_121644) do
     t.string "chart_unit"
     t.string "chart_value"
     t.bigint "record_date_id"
-    t.index ["record_date_id", "parameter"], name: "index_hemigrams_on_record_date_id_and_parameter", unique: true
+    t.index ["record_date_id", "parameter", "user_id"], name: "index_hemigrams_on_record_date_id_and_parameter_and_user_id", unique: true
     t.index ["record_date_id"], name: "index_hemigrams_on_record_date_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,12 +25,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_06_211955) do
 
   create_table "hemigram_dates", force: :cascade do |t|
     t.date "date", null: false
-    t.bigint "hemigram_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["date", "hemigram_id"], name: "index_hemigram_dates_on_date_and_hemigram_id", unique: true
     t.index ["date"], name: "index_hemigram_dates_on_date"
-    t.index ["hemigram_id"], name: "index_hemigram_dates_on_hemigram_id"
   end
 
   create_table "hemigrams", force: :cascade do |t|
@@ -44,6 +41,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_06_211955) do
     t.string "short"
     t.string "chart_unit"
     t.string "chart_value"
+    t.bigint "record_date_id"
+    t.index ["record_date_id", "parameter"], name: "index_hemigrams_on_record_date_id_and_parameter", unique: true
+    t.index ["record_date_id"], name: "index_hemigrams_on_record_date_id"
   end
 
   create_table "hemigrams_chart_settings", force: :cascade do |t|
@@ -96,7 +96,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_06_211955) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  add_foreign_key "hemigram_dates", "hemigrams"
+  add_foreign_key "hemigrams", "hemigram_dates", column: "record_date_id"
   add_foreign_key "hemigrams_chart_settings", "users", on_delete: :cascade
   add_foreign_key "hemigrams_parameter_associations", "hemigrams", name: "hemigram_fk"
   add_foreign_key "hemigrams_parameter_associations", "hemigrams_parameter_metadata", column: "parameter_metadata_id", name: "parameter_metadata_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_06_211955) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_12_121644) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,7 +27,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_06_211955) do
     t.date "date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["date"], name: "index_hemigram_dates_on_date"
+    t.index ["user_id"], name: "index_hemigram_dates_on_user_id"
   end
 
   create_table "hemigrams", force: :cascade do |t|
@@ -96,6 +98,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_06_211955) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  add_foreign_key "hemigram_dates", "users"
   add_foreign_key "hemigrams", "hemigram_dates", column: "record_date_id"
   add_foreign_key "hemigrams_chart_settings", "users", on_delete: :cascade
   add_foreign_key "hemigrams_parameter_associations", "hemigrams", name: "hemigram_fk"


### PR DESCRIPTION
a hemigram belongs_to hemigrams::date
a hemigrams::date has_many hemigrams

I created the date objects for the existing hemigrams so that I can remove the date attribute from hemigrams in a next step.